### PR TITLE
fix: adding required dbus-python dependencie

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pync; sys_platform != 'win32'
 win10toast; sys_platform == 'win32'
 notify2; sys_platform == 'linux'
 requests
+dbus-python; sys_platform == 'linux'


### PR DESCRIPTION
 adding required dbus-python dependencie into the requirements.txt file